### PR TITLE
pass key through to component registry

### DIFF
--- a/st_multimodal_chatinput/__init__.py
+++ b/st_multimodal_chatinput/__init__.py
@@ -50,7 +50,7 @@ def multimodal_chatinput(default=None, disabled=False, key=None, placeholder="As
         'uploadedImages' contains only the base64 encoded content of image files.
         'textInput' is a string representing the current text input.
     """
-    component_value = _component_func(disabled=disabled, default=default, placeholder=placeholder)
+    component_value = _component_func(disabled=disabled, default=default, placeholder=placeholder, key=key)
     
     # Ensure backward compatibility for uploadedImages
     if component_value is not None and 'uploadedFiles' in component_value:


### PR DESCRIPTION
After this change, by passing a new unique key,
you can create a new multimodal_chatinput inside an st.empty() container. You can do this every time after you've used the chat input to submit a value. This way, the submitted value won't persist in the widget state and get re-submitted if something else on your page changes state (radio button, etc)